### PR TITLE
added a parameter 

### DIFF
--- a/service/v4/SugarWebServiceUtilv4.php
+++ b/service/v4/SugarWebServiceUtilv4.php
@@ -82,7 +82,8 @@ class SugarWebServiceUtilv4 extends SugarWebServiceUtilv3_1
      * if the list should filter for favorites.  Should eventually update the SugarBean function as well.
      *
      */
-    function get_data_list($seed, $order_by = "", $where = "", $row_offset = 0, $limit=-1, $max=-1, $show_deleted = 0, $favorites = false)
+    // added a parameter to make it compatible with php7.X
+    function get_data_list($seed, $order_by = "", $where = "", $row_offset = 0, $limit=-1, $max=-1, $show_deleted = 0, $favorites = false, $single_select=false)
 	{
 		$GLOBALS['log']->debug("get_list:  order_by = '$order_by' and where = '$where' and limit = '$limit'");
 		if(isset($_SESSION['show_deleted']))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
added a parameter to get_data_list to make it compatible with php7.X
I am not sure whether this is the correct way, but sure it is ONE way.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
The rest interface breaks when using PHP7.X
PHP7.X does not allow a mismatch of parameters passed to object inherited functions when extending classes. There are a number of classes extended ESPECIALLY because of the different versions in use of the REST interface. 
The writers of the different version did not add all parameters to the externded classes breaking when using PHP7.X. This was not the case when using < 5.6.X.

The fixes provided add some DUMMY parameters to fix this.
I am 50% sure this is not the way to do it but I want to get the ball rolling ....

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Can't use the rest interface when using PHP7.X
Please see https://github.com/salesagility/SuiteCRM/issues/3262

## How To Test This
<!--- Please describe in detail how to test your changes. -->
There are files and examples attached to #3262 that explain this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
